### PR TITLE
Fixes for void pointer

### DIFF
--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -174,7 +174,7 @@ function loadUserLibs(): bb.DeclParseResult {
                     range: toker.range(),
                     severity: vscode.DiagnosticSeverity.Error
                 });
-                const tag = '%#$'.includes(toker.next()) ? toker.curr() : '.null';
+                const tag = '%#$'.includes(toker.next()) ? toker.curr() : 'null';
                 if ('%#$'.includes(tag)) toker.next();
 
                 if (toker.curr() != '(') diagnostics.push({

--- a/src/util/functions.ts
+++ b/src/util/functions.ts
@@ -92,7 +92,8 @@ export function isIllegalTypeConversion(source: string, dest: string): number {
                 case '?':
                 case '%':
                 case '#':
-                case '$': return 0;
+                case '$':
+                case '*': return 0;
                 default: return 2;
             }
         case '%':
@@ -100,7 +101,8 @@ export function isIllegalTypeConversion(source: string, dest: string): number {
                 case '?': return 1;
                 case '%':
                 case '#':
-                case '$': return 0;
+                case '$':
+                case '*': return 0;
                 default: return 2;
             }
         case '#':
@@ -120,7 +122,7 @@ export function isIllegalTypeConversion(source: string, dest: string): number {
                 default: return 2;
             }
         case 'null':
-            return '?%#$'.includes(dest) ? 2 : 0;
+            return '?%#$*'.includes(dest) ? 2 : 0;
         default:
             return source == dest ? 0 : 2;
     }


### PR DESCRIPTION
As mentioned in issue #12, this fixes the error which occurs when you try to pass any value to void pointers ("*" type) in userlibs.

Also fixed a typo where ".null" appeared as "..null".